### PR TITLE
Theoretical fix for Safari image smart-paste.

### DIFF
--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -48,7 +48,7 @@ export default class UploadButton extends Component {
                 ])}
                 icon={buttonIcon}
                 onclick={this.buttonClicked.bind(this)}>
-                {this.isLoading && <LoadingIndicator size="small" display="inline" />}
+                {this.isLoading && <LoadingIndicator size="small" display="inline"/>}
                 <span className="Button-label">{label}</span>
                 <form>
                     <input type="file" accept="image/*" onchange={this.formUpload.bind(this)}
@@ -60,10 +60,9 @@ export default class UploadButton extends Component {
 
     paste(e) {
         if (this.isLoading) return;
+        if (!e.clipboardData) return;
 
-        if (e.clipboardData && e.clipboardData.items) {
-            let item = e.clipboardData.items[0];
-
+        for (let item of e.clipboardData.items) {
             if (!item.type.startsWith('image')) {
                 return;
             }

--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -63,9 +63,7 @@ export default class UploadButton extends Component {
         if (!e.clipboardData) return;
 
         for (let item of e.clipboardData.items) {
-            if (!item.type.startsWith('image')) {
-                return;
-            }
+            if (!item.type.startsWith('image')) continue;
 
             let file = item.getAsFile();
             this.upload(file);


### PR DESCRIPTION
Length check has been removed as foreach loop doesn't enter if length is zero.
This should also add support for album pasting.

Note: No extended testing has been done as no test environment was available, just some stuff on jsfiddle to see if interactions are good.